### PR TITLE
#2 change background of select to be transparent:

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,22 @@
+let pkgs = import <nixpkgs> {};
+
+    buildNodejs = pkgs.callPackage <nixpkgs/pkgs/development/web/nodejs/nodejs.nix> {};
+
+    nodejs-14 = buildNodejs {
+        version = "14.17.1";
+        sha256 = "0zr4b9gja8f9611rnmc9yacmh90bd76xv9ayikcyqdfzdpax5wfx";
+    };
+
+
+in pkgs.mkShell rec {
+    name = "que-toca";
+  
+    buildInputs = with pkgs; [
+        nodejs-14
+    ];
+
+    shellHook = ''
+        export PATH="$PWD/node_modules/.bin/:$PATH"
+        pnpm --help >/dev/null || npm install --no-save pnpm
+    '';
+}

--- a/src/components/Navegation.vue
+++ b/src/components/Navegation.vue
@@ -30,7 +30,7 @@
             <router-link to="/about" :title="t('button.about')" class="mt-2 md:mt-0 md:mx-4 text-center hover:text-gray-800 dark:hover:text-gray-200">
               {{ t('button.about') }}
             </router-link>
-            <select id="" name="province">
+            <select id="" name="province" class="bg-transparent">
               <option value="santo_domingo">
                 Santo Domingo
               </option>


### PR DESCRIPTION
* also added a shell.nix file: useful when one doesn't want to install npm globally, and use nixpkgs instead
ref: https://nixos.org/

that shell.nix is for dependency management (we can pin the exact version of node that was used to develop this).

the page looks as follows with the changes:
![image](https://user-images.githubusercontent.com/7826376/123545716-6f073c00-d751-11eb-95b7-8692c7544974.png)

This fixes: https://github.com/ricardov03/que-toca/issues/3

cc: @lecollabdul 
